### PR TITLE
Add Hivekeep

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,15 @@ Self-hosted personal AI assistant that runs on any OS and reaches you on any pla
 - **Backends:** Any OpenAI-compatible API, Ollama, LocalAI
 - **Edge:** Gateways into Telegram, Discord, Slack, WhatsApp, Signal, email, and CLI, so the agent reaches you where you already are — and can proactively message *you*. Large skill/plugin ecosystem. **Security note:** it holds credentials for your messaging accounts and runs autonomously; sandbox it and read the permission model before pointing it at anything sensitive.
 
+### [Hivekeep](https://github.com/MarlBurroW/hivekeep)
+`TypeScript` · `MIT`
+
+Self-hosted platform to run a *team* of specialized AI agents that collaborate, keep persistent memory, and build their own tools, mini-apps, and plugins.
+
+- **Replaces:** ChatGPT Team, Claude Desktop, hosted agent platforms
+- **Backends:** Any OpenAI-compatible API, Ollama
+- **Edge:** Multiple agents delegate to each other and share memory across months; a built-in web UI plus Telegram, Slack, Discord, and Matrix channels. Ships as a single container (Bun + SQLite), so the whole platform runs on modest hardware.
+
 ### [Hermes Agent](https://github.com/NousResearch/hermes-agent)
 `Python` · `MIT`
 


### PR DESCRIPTION
Adds Hivekeep to Autonomous & Persistent Agents.

Hivekeep is a self-hosted, MIT-licensed platform to run a *team* of specialized AI agents with persistent memory and a web UI; agents collaborate and build their own tools, mini-apps and plugins; reachable over Telegram, Slack, Discord and Matrix; single container (Bun + SQLite). Entry follows the section format (What it does / Replaces / Backends / Edge).

Disclosure: I am the author of Hivekeep.