### PR TITLE
Add Unified AI System to Inference Servers & Gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,6 +510,15 @@ Distributed compute framework for scaling AI workloads — training, tuning, and
 
 - **Edge:** For when one model on one box is no longer the problem. Model composition and autoscaling across a cluster.
 
+### [Unified AI System](https://github.com/happy520ai/unified-ai-system)
+`TypeScript + JavaScript` · `Apache-2.0` · `Self-hosted gateway + CLI` · 🟡 active
+
+Terminal-first AI gateway that puts provider routing, governed agent and knowledge contracts, and an optional operator workbench behind one self-hosted service.
+
+- **Replaces:** ad hoc provider-specific proxy scripts and hosted gateway control planes for local evaluation
+- **Backends:** deterministic local fake provider by default; OpenAI-compatible and NVIDIA endpoints via explicit configuration
+- **Edge:** A fresh clone can prove the complete chat path without credentials, while the CLI refuses to send when a real provider may be active unless the operator supplies `--allow-real-provider` for that command. Public-clone and container smoke checks keep the credential-free path under CI.
+
 ---
 
 ## Chat UIs & Frontends

--- a/README.md
+++ b/README.md
@@ -513,11 +513,11 @@ Distributed compute framework for scaling AI workloads — training, tuning, and
 ### [Unified AI System](https://github.com/happy520ai/unified-ai-system)
 `TypeScript + JavaScript` · `Apache-2.0` · `Self-hosted gateway + CLI` · 🟡 active
 
-Terminal-first AI gateway that puts provider routing, governed agent and knowledge contracts, and an optional operator workbench behind one self-hosted service.
+Terminal-first AI gateway that puts provider routing, governed agent and knowledge contracts, an HTTP API, and Codex MCP tools behind one self-hosted service.
 
-- **Replaces:** ad hoc provider-specific proxy scripts and hosted gateway control planes for local evaluation
-- **Backends:** deterministic local fake provider by default; OpenAI-compatible and NVIDIA endpoints via explicit configuration
-- **Edge:** A fresh clone can prove the complete chat path without credentials, while the CLI refuses to send when a real provider may be active unless the operator supplies `--allow-real-provider` for that command. Public-clone and container smoke checks keep the credential-free path under CI.
+- **Replaces:** ad hoc provider-specific proxy scripts when evaluating a local AI gateway control plane
+- **Backends:** deterministic local fake provider by default; configurable adapters for NVIDIA and OpenAI-compatible upstream providers
+- **Edge:** A fresh clone can prove the complete chat and MCP paths without credentials, while the CLI refuses to send when a real provider may be active unless the operator supplies `--allow-real-provider` for that command. Public-clone and container smoke checks keep the credential-free path under CI.
 
 ---
 


### PR DESCRIPTION
## Summary

- add Unified AI System to **Inference Servers & Gateways**
- describe its terminal-first, self-hosted gateway scope without promotional superlatives
- highlight the credential-free fake-provider path and per-command authorization boundary for real-provider CLI chat

## Maturity

Classified as **🟡 active**: the canonical repository has a `v0.3.2` public-preview release and active CI/container checks, while its own documentation makes no production-readiness claim.

## Quick evaluation

```bash
docker run --rm ghcr.io/happy520ai/unified-ai-system/ai-gateway-service:0.3.2 pnpm gateway demo
```

The project's Docker workflow verifies this bundled CLI path before publishing the image.

## Verification

- [x] canonical repository is public and not archived
- [x] Apache-2.0 verified from the repository license
- [x] placed in the existing Inference Servers & Gateways category
- [x] positioned at the end of the section to reflect its early maturity
- [x] no existing Unified AI System entry
- [x] one tool in this PR
- [x] `git diff --check` passes

Canonical release: https://github.com/happy520ai/unified-ai-system/releases/tag/v0.3.2

Disclosure: I maintain the submitted project.