### PR TITLE
Add ClawBench to Evals, Testing & Guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -719,6 +719,13 @@ Test and evaluate prompts, agents, and RAG systems — plus LLM red teaming and 
 
 - **Edge:** Declarative test cases in YAML that run in CI. Side-by-side model comparison plus adversarial red-teaming in one tool. Local-first — your prompts never leave your machine.
 
+### [ClawBench](https://github.com/reacher-z/ClawBench)
+`Python` · `Apache-2.0` · Docker/browser harness · 🟡 active
+
+Evaluate web agents on 153 everyday tasks across 144 live websites, with the final submission request intercepted to keep runs side-effect-free.
+
+- **Edge:** Captures session replay, screenshots, HTTP traffic, browser actions, and agent messages in one reproducible run, making failures diagnosable beyond a final pass/fail score.
+
 ### [DeepEval](https://github.com/confident-ai/deepeval)
 `Python` · `Apache-2.0` · 🟢 stable
 
@@ -954,4 +961,3 @@ The bar for inclusion:
 [![CC0](https://licensebuttons.net/p/zero/1.0/88x31.png)](LICENSE)
 
 To the extent possible under law, contributors have waived all copyright and related rights to this work.
-


### PR DESCRIPTION
ClawBench is an actively maintained Apache-2.0 benchmark framework for evaluating web agents on real-world tasks.

This adds it to the Evals, Testing & Guardrails section using the repository's native entry format. The description is factual: 153 tasks across 144 live websites, final-request interception, and five-layer execution evidence.

Checklist:
- Canonical repository link
- Apache-2.0 verified in the ClawBench repository
- One tool in one PR
- No star count added