### PR TITLE
Add ordewell to Coding Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Local-first desktop AI workforce where a Commander plans work and coordinates bu
 - **Replaces:** Cursor agent mode, cloud-hosted agent orchestrators
 - **Backends:** Claude, OpenAI, Gemini, DeepSeek, Kimi, GLM, Qwen, MiniMax, Doubao, and compatible local model endpoints
 - **Edge:** Orkas runs the orchestration layer on the user's machine: conversations, files, agent configuration, and model keys stay local, while the Commander can dispatch Claude Code, Codex, OpenCode, and Cline as local subprocesses alongside built-in agents.
+- [ordewell](https://github.com/ordewell/ordewell) — Plan-first CLI/TUI orchestrator: one goal in, a read-only planner returns an ordered, editable plan of coding-agent tasks (Claude Code, Codex, OpenCode), each with its own runner/model/mode. Apache-2.0.
 
 ### [Kilo Code](https://github.com/Kilo-Org/kilocode)
 `TypeScript` · `Apache-2.0` · VS Code + JetBrains · 🟢 stable

--- a/README.md
+++ b/README.md
@@ -124,7 +124,15 @@ Local-first desktop AI workforce where a Commander plans work and coordinates bu
 - **Replaces:** Cursor agent mode, cloud-hosted agent orchestrators
 - **Backends:** Claude, OpenAI, Gemini, DeepSeek, Kimi, GLM, Qwen, MiniMax, Doubao, and compatible local model endpoints
 - **Edge:** Orkas runs the orchestration layer on the user's machine: conversations, files, agent configuration, and model keys stay local, while the Commander can dispatch Claude Code, Codex, OpenCode, and Cline as local subprocesses alongside built-in agents.
-- [ordewell](https://github.com/ordewell/ordewell) — Plan-first CLI/TUI orchestrator: one goal in, a read-only planner returns an ordered, editable plan of coding-agent tasks (Claude Code, Codex, OpenCode), each with its own runner/model/mode. Apache-2.0.
+
+### [ordewell](https://github.com/ordewell/ordewell)
+`Rust` · `Apache-2.0` · CLI / TUI · 🟡 active
+
+Plan-first CLI/TUI orchestrator that converts a single goal into an ordered, editable plan of coding-agent tasks.
+
+- **Replaces:** Manual task decomposition and multi-agent CLI scripting
+- **Backends:** Claude Code, Codex, OpenCode
+- **Edge:** Features a read-only planner that generates explicit step-by-step agent plans before execution, with per-task runner, model, and mode assignment.
 
 ### [Kilo Code](https://github.com/Kilo-Org/kilocode)
 `TypeScript` · `Apache-2.0` · VS Code + JetBrains · 🟢 stable


### PR DESCRIPTION
Adds ordewell to the Coding Agents & Pair Programmers section. Open-source (Apache-2.0) plan-first CLI/TUI orchestrator for coding agents.