### PR TITLE
Add BitFun to Coding Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,15 @@ Extensible autonomous agent from Block, now governed by the Linux Foundation. In
 - **Backends:** Any provider, plus first-class MCP extension support
 - **Edge:** More autonomous than aider — plans and iterates with less hand-holding. Vendor-neutral governance under the Linux Foundation means no rug-pull risk, which matters for tooling you standardize a team on.
 
+### [BitFun](https://github.com/GCWing/BitFun)
+`Rust + TypeScript` · `MIT` · Desktop + CLI · 🟡 active
+
+Cross-platform coding and desktop agent that plans, edits, tests, and commits inside real Git repositories.
+
+- **Replaces:** Cursor, Claude Desktop
+- **Backends:** User-configured model providers; model-agnostic by design
+- **Edge:** A Rust runtime binds each conversation to task-specific Mini Apps while retaining filesystem, terminal, Git, browser, desktop, and remote-workspace execution. A self-hostable zero-knowledge relay supports cross-device session control without routing workspace data through a vendor cloud.
+
 ### [Orkas](https://github.com/Orkas-AI/Orkas)
 `TypeScript` · `MIT` · Desktop · 🟡 active
 
@@ -903,7 +912,7 @@ Visual framework for building multi-agent and RAG applications.
 | You're paying for | Use instead |
 |---|---|
 | GitHub Copilot | [Continue](https://github.com/continuedev/continue), [Tabby](https://github.com/TabbyML/tabby), [aider](https://github.com/Aider-AI/aider) |
-| Cursor / Windsurf | [Cline](https://github.com/cline/cline), [OpenCode](https://github.com/sst/opencode), [Continue](https://github.com/continuedev/continue) |
+| Cursor / Windsurf | [Cline](https://github.com/cline/cline), [OpenCode](https://github.com/sst/opencode), [Continue](https://github.com/continuedev/continue), [BitFun](https://github.com/GCWing/BitFun) |
 | Devin | [OpenHands](https://github.com/All-Hands-AI/OpenHands), [Goose](https://github.com/block/goose), [SWE-agent](https://github.com/SWE-agent/SWE-agent) |
 | Claude Design / Figma Make | [Open Design](https://github.com/nexu-io/open-design) |
 | ChatGPT desktop / Copilot assistant | [OpenClaw](https://github.com/openclaw/openclaw), [Hermes Agent](https://github.com/NousResearch/hermes-agent) |


### PR DESCRIPTION
## Summary

Adds [BitFun](https://github.com/GCWing/BitFun) to **Coding Agents & Pair Programmers** and updates the alternatives cheat sheet.

## Why it belongs

BitFun is an actively maintained, MIT-licensed desktop and CLI agent that plans, edits, tests, reviews, and commits inside real Git repositories. Its technical distinction is a Rust runtime that combines coding tools with browser, desktop, remote-workspace, and task-specific Mini App execution, plus an optional self-hosted relay for cross-device control.

## Classification

- Category: Coding Agents & Pair Programmers
- Maturity: 🟡 active
- Form factor: Desktop + CLI
- Languages: Rust + TypeScript
- License: MIT

## Checklist

- Canonical repository link
- License verified from the repository LICENSE file
- Latest release is v0.2.17 and development is active
- Specific technical Edge line, without star counts
- Cheat sheet updated for the Cursor / Windsurf alternative row
- One tool in this PR

## Disclosure

This is a project self-submission made on behalf of BitFun.
