### PR TITLE
Add Atomic Agent to Coding Agents & Pair Programmers

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,15 @@ Plan-first CLI/TUI orchestrator that converts a single goal into an ordered, edi
 - **Backends:** Claude Code, Codex, OpenCode
 - **Edge:** Features a read-only planner that generates explicit step-by-step agent plans before execution, with per-task runner, model, and mode assignment.
 
+### [Atomic Agent](https://github.com/AtomicBot-ai/atomic-agent)
+`TypeScript` · `MIT` · CLI + TUI · 🟠 experimental
+
+Local-first coding and desktop agent that runs open-weight models on your machine, with no account or API key needed to install and run it.
+
+- **Replaces:** Claude Code, Cursor, GitHub Copilot
+- **Backends:** Bundled `llama.cpp` fork for local quantized models, plus any OpenAI-compatible endpoint, OpenRouter, Ollama, and LM Studio
+- **Edge:** Ships its own `llama.cpp` fork and manages the backend process itself, so a quantized local model stays usable across long multi-step runs without a separate server setup. The control loop and all state, including a five-layer memory store, stay on the machine, and 56 built-in tools cover browser, filesystem, git, and vision alongside external MCP servers. The README labels it a developer preview: APIs, commands, and config still move between releases.
+
 ### [Kilo Code](https://github.com/Kilo-Org/kilocode)
 `TypeScript` · `Apache-2.0` · VS Code + JetBrains · 🟢 stable
 
@@ -920,7 +929,7 @@ Visual framework for building multi-agent and RAG applications.
 | You're paying for | Use instead |
 |---|---|
 | GitHub Copilot | [Continue](https://github.com/continuedev/continue), [Tabby](https://github.com/TabbyML/tabby), [aider](https://github.com/Aider-AI/aider) |
-| Cursor / Windsurf | [Cline](https://github.com/cline/cline), [OpenCode](https://github.com/sst/opencode), [Continue](https://github.com/continuedev/continue), [BitFun](https://github.com/GCWing/BitFun) |
+| Cursor / Windsurf | [Cline](https://github.com/cline/cline), [OpenCode](https://github.com/sst/opencode), [Continue](https://github.com/continuedev/continue), [BitFun](https://github.com/GCWing/BitFun), [Atomic Agent](https://github.com/AtomicBot-ai/atomic-agent) |
 | Devin | [OpenHands](https://github.com/All-Hands-AI/OpenHands), [Goose](https://github.com/block/goose), [SWE-agent](https://github.com/SWE-agent/SWE-agent) |
 | Claude Design / Figma Make | [Open Design](https://github.com/nexu-io/open-design) |
 | ChatGPT desktop / Copilot assistant | [OpenClaw](https://github.com/openclaw/openclaw), [Hermes Agent](https://github.com/NousResearch/hermes-agent) |

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Plan-first CLI/TUI orchestrator that converts a single goal into an ordered, edi
 Local-first coding and desktop agent that runs open-weight models on your machine, with no account or API key needed to install and run it.
 
 - **Replaces:** Claude Code, Cursor, GitHub Copilot
-- **Backends:** Bundled `llama.cpp` fork for local quantized models, plus any OpenAI-compatible endpoint, OpenRouter, Ollama, and LM Studio
+- **Backends:** Bundled `llama.cpp` fork for local quantized models, plus any OpenAI-compatible endpoint, with presets for OpenRouter, LM Studio, and Ollama Cloud
 - **Edge:** Ships its own `llama.cpp` fork and manages the backend process itself, so a quantized local model stays usable across long multi-step runs without a separate server setup. The control loop and all state, including a five-layer memory store, stay on the machine, and 56 built-in tools cover browser, filesystem, git, and vision alongside external MCP servers. The README labels it a developer preview: APIs, commands, and config still move between releases.
 
 ### [Kilo Code](https://github.com/Kilo-Org/kilocode)


### PR DESCRIPTION
Hi! I'm the CPO of Atomic Agent. Thanks for building this list, the "what does it replace / why pick it" structure is genuinely the most useful format I've seen for the open-source AI stack. Our team would be thrilled to be included.

Adding [Atomic Agent](https://github.com/AtomicBot-ai/atomic-agent) to **Coding Agents & Pair Programmers**.

A local-first coding and desktop agent (CLI + TUI, TypeScript, MIT). It runs open-weight models on your machine through a bundled `llama.cpp` fork, and needs no account or API key to install and run. It also talks to any OpenAI-compatible endpoint, with built-in presets for OpenRouter, LM Studio, and Ollama Cloud.

On the maturity badge, I picked 🟠 **experimental** on purpose. We're on `v0.2.0`, and our own README says in as many words: "Developer preview. APIs, commands, config, and behavior are still moving." By your decision order (release tag, then commit cadence, then does the README warn you itself) that is an honest 🟠, even though commit cadence alone would argue for 🟡. Happy to defer to your call if you read it differently.

One disambiguation worth flagging: there is a separate, larger project called [Atomic Agents](https://github.com/BrainBlend-AI/atomic-agents) by BrainBlend-AI. Unrelated to us, different product. It isn't currently on the list, but if you ever add it, ours is the one under the `AtomicBot-ai` organization.

**Checklist**

- [x] Link goes to the canonical repo (not a fork, not a marketing site)
- [x] License is accurate, verified against the `LICENSE` file in the repo (MIT)
- [x] Placed in the correct category
- [x] Entries within a category are ordered roughly by relevance
- [x] "Edge" line is specific and technical
- [x] Maturity badge set and matches the criteria
- [x] Updated the cheat sheet table (added us to the Cursor / Windsurf row)
- [x] One tool per PR

I edited `README.md` only, since `scripts/sync-docs-index.mjs` regenerates `docs/` on push to main. I ran that script locally to confirm the new section parses cleanly, then reverted its output.

More context if useful: [atomicagent.io](https://atomicagent.io) · [docs](https://atomicagent.io/docs) · [Discord](https://discord.gg/Us7qXtDGw) · [@atomicagent_io](https://x.com/atomicagent_io)

Glad to adjust the wording, badge, or placement to fit your conventions. Thanks for considering it.
