### PR TITLE
Add Mydentify AI Model Cost Calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -847,6 +847,13 @@ Observability platform for LLM apps — one-line proxy integration, caching, and
 
 - **Edge:** Change your base URL and you have logging. Lowest-friction start of any tool in this section.
 
+### [Mydentify AI Model Cost Calculator](https://github.com/mitdralla/mydentify-ai-model-cost-calculator)
+`JavaScript` · `MIT` · Browser app · 🟠 experimental
+
+Dependency-free browser calculator for estimating AI model API costs from request volume, input and output tokens, cached input, and fixed per-request charges.
+
+- **Edge:** Runs locally without API keys, accounts, cookies, analytics, or server-side processing. The tested formula separates cached from uncached input and keeps provider-specific pricing assumptions visible so estimates can be reviewed before a real bill is incurred.
+
 ---
 
 ## Speech, Vision & Multimodal


### PR DESCRIPTION
Adds one factual entry under Observability & LLMOps.

The MIT-licensed, actively maintained project is a dependency-free browser calculator for estimating AI model API costs from request volume, input/output tokens, cached input, and fixed per-request charges. It runs locally without keys, accounts, cookies, analytics, or server-side processing.

The entry is marked experimental because the project is young and has no v1 release yet. Disclosure: I maintain the linked repository. No reciprocal link or engagement is requested.