### PR TITLE
Add SandBase CLI to MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,7 +446,7 @@ The ergonomic way to build MCP servers and clients — decorator-based, like Fas
 ### [SandBase CLI](https://github.com/sandbaseai/cli)
 `TypeScript` · `Apache-2.0` · CLI + MCP bridge · 🟡 active
 
-Connects 17+ coding-agent clients to a hosted catalog of 2,000+ tools and 200+ AI models through MCP.
+Connects 17+ coding-agent clients to a hosted catalog of 2,000+ AI models and APIs through MCP.
 
 - **Replaces:** per-provider API wrappers and repeated MCP configuration across agent clients
 - **Backends:** SandBase's hosted API catalog, including web search, social data, scraping, multimodal generation, and model APIs

--- a/README.md
+++ b/README.md
@@ -443,6 +443,15 @@ The ergonomic way to build MCP servers and clients — decorator-based, like Fas
 
 - **Edge:** A working server in ~10 lines. Handles auth, deployment, proxying, and server composition.
 
+### [SandBase CLI](https://github.com/sandbaseai/cli)
+`TypeScript` · `Apache-2.0` · CLI + MCP bridge · 🟡 active
+
+Connects 17+ coding-agent clients to a hosted catalog of 2,000+ tools and 200+ AI models through MCP.
+
+- **Replaces:** per-provider API wrappers and repeated MCP configuration across agent clients
+- **Backends:** SandBase's hosted API catalog, including web search, social data, scraping, multimodal generation, and model APIs
+- **Edge:** One `connect` command detects supported clients and writes their native MCP or Skill configuration; credentials use an OAuth device flow, stay in a local `0600` file, and are never passed in command-line arguments. The local bridge exposes a small discover → inspect → run tool surface instead of loading thousands of tool schemas into every agent context.
+
 ### [octocode](https://github.com/Muvon/octocode)
 `Rust` · `Apache-2.0` · 🟠 experimental
 

--- a/docs/categories/02-open-source-agents.md
+++ b/docs/categories/02-open-source-agents.md
@@ -228,6 +228,15 @@ The ergonomic way to build MCP servers and clients — decorator-based, like Fas
 
 - **Edge:** A working server in ~10 lines. Handles auth, deployment, proxying, and server composition.
 
+### [SandBase CLI](https://github.com/sandbaseai/cli)
+`TypeScript` · `Apache-2.0` · CLI + MCP bridge · 🟡 active
+
+Connects 17+ coding-agent clients to a hosted catalog of 2,000+ tools and 200+ AI models through MCP.
+
+- **Replaces:** per-provider API wrappers and repeated MCP configuration across agent clients
+- **Backends:** SandBase's hosted API catalog, including web search, social data, scraping, multimodal generation, and model APIs
+- **Edge:** One `connect` command detects supported clients and writes their native MCP or Skill configuration; credentials use an OAuth device flow, stay in a local `0600` file, and are never passed in command-line arguments. The local bridge exposes a small discover → inspect → run tool surface instead of loading thousands of tool schemas into every agent context.
+
 ### [octocode](https://github.com/Muvon/octocode)
 `Rust` · `Apache-2.0` · 🟠 experimental
 

--- a/docs/categories/02-open-source-agents.md
+++ b/docs/categories/02-open-source-agents.md
@@ -231,7 +231,7 @@ The ergonomic way to build MCP servers and clients — decorator-based, like Fas
 ### [SandBase CLI](https://github.com/sandbaseai/cli)
 `TypeScript` · `Apache-2.0` · CLI + MCP bridge · 🟡 active
 
-Connects 17+ coding-agent clients to a hosted catalog of 2,000+ tools and 200+ AI models through MCP.
+Connects 17+ coding-agent clients to a hosted catalog of 2,000+ AI models and APIs through MCP.
 
 - **Replaces:** per-provider API wrappers and repeated MCP configuration across agent clients
 - **Backends:** SandBase's hosted API catalog, including web search, social data, scraping, multimodal generation, and model APIs

--- a/docs/index.md
+++ b/docs/index.md
@@ -446,7 +446,7 @@ The ergonomic way to build MCP servers and clients — decorator-based, like Fas
 ### [SandBase CLI](https://github.com/sandbaseai/cli)
 `TypeScript` · `Apache-2.0` · CLI + MCP bridge · 🟡 active
 
-Connects 17+ coding-agent clients to a hosted catalog of 2,000+ tools and 200+ AI models through MCP.
+Connects 17+ coding-agent clients to a hosted catalog of 2,000+ AI models and APIs through MCP.
 
 - **Replaces:** per-provider API wrappers and repeated MCP configuration across agent clients
 - **Backends:** SandBase's hosted API catalog, including web search, social data, scraping, multimodal generation, and model APIs

--- a/docs/index.md
+++ b/docs/index.md
@@ -443,6 +443,15 @@ The ergonomic way to build MCP servers and clients — decorator-based, like Fas
 
 - **Edge:** A working server in ~10 lines. Handles auth, deployment, proxying, and server composition.
 
+### [SandBase CLI](https://github.com/sandbaseai/cli)
+`TypeScript` · `Apache-2.0` · CLI + MCP bridge · 🟡 active
+
+Connects 17+ coding-agent clients to a hosted catalog of 2,000+ tools and 200+ AI models through MCP.
+
+- **Replaces:** per-provider API wrappers and repeated MCP configuration across agent clients
+- **Backends:** SandBase's hosted API catalog, including web search, social data, scraping, multimodal generation, and model APIs
+- **Edge:** One `connect` command detects supported clients and writes their native MCP or Skill configuration; credentials use an OAuth device flow, stay in a local `0600` file, and are never passed in command-line arguments. The local bridge exposes a small discover → inspect → run tool surface instead of loading thousands of tool schemas into every agent context.
+
 ### [octocode](https://github.com/Muvon/octocode)
 `Rust` · `Apache-2.0` · 🟠 experimental
 


### PR DESCRIPTION
## Summary

Add SandBase CLI to the Model Context Protocol (MCP) section across the canonical README and generated documentation copies.

SandBase CLI is an Apache-2.0, agent-first CLI and MCP bridge. One connection lets Claude Code, Codex, Cursor, Gemini CLI, OpenCode, Windsurf, and other supported clients discover and invoke 2,000+ models and APIs through six MCP tools.

## Fit and maintenance

- Open source: Apache-2.0
- Published npm package: `@sandbaseai/cli` v0.1.14
- Usage: 1,776 npm downloads in the latest completed monthly reporting window; 109 in the latest completed week
- Active support for multiple MCP-capable developer clients
- Documents the replacement value, backends, and distinguishing edge in the list's existing format

Disclosure: I am affiliated with the project. AI assistance was used to prepare this contribution.