### PR TITLE
Add Mac Developer Bridge to MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,13 @@ Reference implementations — filesystem, git, fetch, memory, and dozens of comm
 
 - **Edge:** The fastest way to learn the protocol is to read a 200-line server that already works.
 
+### [Mac Developer Bridge](https://github.com/alexanderradahl/mac-developer-bridge)
+`JavaScript` · `MIT` · macOS / MCP · 🟠 experimental
+
+Local MCP bridge that lets an existing ChatGPT conversation operate the Mac where the developer is already working: shell, unrestricted files, real PTY sessions, background jobs, and read-only Codex history.
+
+- **Edge:** ChatGPT stays the reasoning layer and the bridge makes no model calls. Unlike a narrow filesystem or shell MCP, it is deliberately built for developer-machine parity and real interactive terminals. **Security tradeoff:** it is intentionally not sandboxed and runs with the macOS user's effective permissions, so it is only appropriate when that level of machine access is explicitly wanted.
+
 ### [MCP Inspector](https://github.com/modelcontextprotocol/inspector)
 `TypeScript` · `MIT` · 🟡 active
 


### PR DESCRIPTION
Adds [Mac Developer Bridge](https://github.com/alexanderradahl/mac-developer-bridge) to the **Model Context Protocol (MCP)** section.

It is MIT-licensed, macOS-specific, and actively maintained. I marked it **experimental** because it is a new project. The entry explains both the differentiator (normal ChatGPT remains the reasoning layer; no second model loop, plus real PTYs and read-only Codex history) and the important tradeoff: it is intentionally unsandboxed and carries the macOS user's effective permissions.

Disclosure: I maintain the linked project. No reciprocal link or engagement is requested.