### PR TITLE
Add agent-qa to Evals, Testing & Guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -772,6 +772,14 @@ Test and evaluate prompts, agents, and RAG systems — plus LLM red teaming and 
 
 - **Edge:** Declarative test cases in YAML that run in CI. Side-by-side model comparison plus adversarial red-teaming in one tool. Local-first — your prompts never leave your machine.
 
+### [agent-qa](https://github.com/vostride/agent-qa)
+`TypeScript` · `FSL-1.1-ALv2` (fair-code; converts to `Apache-2.0`) · CLI, dashboard, MCP · 🟠 experimental
+
+The self-improving QA agent for software teams, with natural-language web and mobile tests that adapt when user interfaces change.
+
+- **Backends:** OpenAI- and Anthropic-compatible endpoints, Gemini, and local models
+- **Edge:** Stores product, suite, test, and healed-step observations as versioned execution memory, then reuses that context on later runs. Ships a dashboard, CLI, MCP server, and three agent skills in one repository.
+
 ### [ClawBench](https://github.com/reacher-z/ClawBench)
 `Python` · `Apache-2.0` · Docker/browser harness · 🟡 active
 


### PR DESCRIPTION
## Summary

Adds agent-qa to **Evals, Testing & Guardrails** using the catalog's full entry format.

The entry describes its natural-language web/mobile testing, execution memory, self-healing, supported model backends, CLI/dashboard/MCP form factors, and three Agent Skills. It labels the current FSL-1.1-ALv2 license as fair-code and notes its Apache-2.0 future license, as required for source-available projects.

The maturity badge is **experimental** because the repository is active and documented but has no GitHub release or version tag yet.

## Validation

- The license was verified against the repository's `LICENSE.md`.
- The canonical repository, documentation, and license URLs return HTTP 200.
- `node skills/scripts/validate-skills.mjs` passes in the source repository.
- The project was not already listed or proposed.
- Entry structure and `git diff --check` pass.

Project disclosure: this submission is for agent-qa itself.
