### PR TITLE
Add Rapid-MLX to Local Inference Engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,7 +511,7 @@ Distribute an entire LLM as one executable file that runs on multiple OSes witho
 - **Edge:** Unbeatable for shipping a model to a non-technical user. One file. Double-click. Done.
 
 ### [Rapid-MLX](https://github.com/raullenchai/Rapid-MLX)
-`Python` · `Apache-2.0` · 🟢 stable
+`Python` · `Apache-2.0` · 🟡 active
 
 OpenAI-compatible inference server built specifically for Apple Silicon, on Apple's MLX framework.
 

--- a/README.md
+++ b/README.md
@@ -510,6 +510,14 @@ Distribute an entire LLM as one executable file that runs on multiple OSes witho
 
 - **Edge:** Unbeatable for shipping a model to a non-technical user. One file. Double-click. Done.
 
+### [Rapid-MLX](https://github.com/raullenchai/Rapid-MLX)
+`Python` · `Apache-2.0` · 🟢 stable
+
+OpenAI-compatible inference server built specifically for Apple Silicon, on Apple's MLX framework.
+
+- **Replaces:** Ollama / LM Studio (on a Mac)
+- **Edge:** MLX-native quantization tuned for the unified-memory envelope, with grammar-constrained tool calling, reasoning separation, and vision — verified end-to-end against Claude Code, Cursor, Aider and Codex. `brew install rapid-mlx`, then `rapid-mlx serve <model>`.
+
 ---
 
 ## Inference Servers & Gateways


### PR DESCRIPTION
Adds **Rapid-MLX** to the *Local Inference Engines* section.

[Rapid-MLX](https://github.com/raullenchai/Rapid-MLX) is an Apache-2.0, OpenAI-compatible inference server built specifically for Apple Silicon on Apple's MLX framework — a natural companion to Ollama / llama.cpp / MLC LLM already in this section, but Mac-native. It ships grammar-constrained tool calling, reasoning separation, and vision, and is verified end-to-end against Claude Code, Cursor, Aider and Codex. `brew install rapid-mlx` (Homebrew core), then `rapid-mlx serve <model>`.

Entry follows the existing format (language · license · status, one-line summary, **Replaces** / **Edge** bullets). Happy to adjust wording or placement — thanks for maintaining this list!